### PR TITLE
chore: TYPO3 12 compatability

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
-name: "typo3-conf-js"
-type: "typo3"
-docroot: ".build/public"
-php_version: "7.4"
+name: typo3-conf-js
+type: typo3
+docroot: .build/public
+php_version: "8.1"
 webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -9,7 +9,7 @@ xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 database:
-  type: "mysql"
+  type: mysql
   version: "8.0"
 nfs_mount_enabled: false
 mutagen_enabled: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: true
       matrix:
         php-version:
-          - 7.4
-          - 8.0
           - 8.1
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@
 ### >jop-software/ci-tooling
 .phpcs-cache
 ### <jop-software/ci-tooling
+
+### >jop-software/typo3-extension
+/var
+/config
+### <jop-software/typo3-extension

--- a/Classes/ViewHelpers/ExtensionConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/ExtensionConfigurationViewHelper.php
@@ -28,6 +28,7 @@ class ExtensionConfigurationViewHelper extends AbstractViewHelper
      */
     private function loadExtensionConfigurationFor(string $extKey): ?array
     {
+        /** @var ExtensionConfiguration $extensionConfiguration */
         $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
 
         try {

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  JopSoftware\TYPO3\ConfJs\:
+    resource: '../Classes/*'

--- a/Tests/Packages/testing-site-package/Configuration/TCA/Overrides/sys_template.php
+++ b/Tests/Packages/testing-site-package/Configuration/TCA/Overrides/sys_template.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
+if (!defined('TYPO3')) {
     die('Access denied.');
 }
 

--- a/Tests/Packages/testing-site-package/composer.json
+++ b/Tests/Packages/testing-site-package/composer.json
@@ -17,7 +17,7 @@
 		}
 	},
 	"require": {
-		"typo3/cms-core": "^11.5"
+		"typo3/cms-core": "^11.5 || ^12.0"
 	},
 	"minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -22,19 +22,18 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": ">=8.1",
     "ext-json": "*",
-    "typo3/cms-core": "^11.5",
+    "typo3/cms-core": "^11.5 || ^12.0",
     "typo3fluid/fluid": "^2.7"
   },
   "require-dev": {
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.0",
     "rector/rector": "0.13.3",
-    "saschaegerer/phpstan-typo3": "^1.0",
     "squizlabs/php_codesniffer": "^3.6",
-    "typo3/minimal": "^v11.5.0",
-    "typo3/cms-tstemplate": "^11.5",
+    "typo3/minimal": "^v11.5 || ^v12.0",
+    "typo3/cms-tstemplate": "^11.5 || ^12.0",
     "jop-software/testing-site-package": "@dev"
   },
   "config": {
@@ -50,7 +49,6 @@
   },
   "extra": {
     "typo3/cms": {
-      "app-dir": ".build",
       "extension-key": "conf_js",
       "web-dir": ".build/public"
     }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,8 +12,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-11.99.99',
-            'php' => '7.4.0-8.1.99',
+            'typo3' => '11.5.0-12.0.99',
+            'php' => '8.1.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
Note: TYPO3 requires PHP 8.1, so this is a **breaking change**